### PR TITLE
BUGFIX: Only ignore paths that contain `typo3` in the relative path

### DIFF
--- a/CDXTYPO3/ruleset.xml
+++ b/CDXTYPO3/ruleset.xml
@@ -4,7 +4,7 @@
     <rule ref="CDXPHP"/>
 
     <!-- Exclude third party code -->
-    <exclude-pattern>*/typo3/*</exclude-pattern>
+    <exclude-pattern type="relative">*/typo3/*</exclude-pattern>
 
     <!-- Arrays -->
     <rule ref="Squiz.Arrays.ArrayBracketSpacing" />


### PR DESCRIPTION
We only want to ignore the typical `typo3` subfolder which contains
most of the TYPO3 core.

Related: #11